### PR TITLE
Precommit and prepush code quality hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "standard"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "standard"
+  "extends": [
+    "standard",
+    "plugin:react/recommended"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"test": "react-scripts test --env=jsdom",
 		"eject": "react-scripts eject",
 		"test:ci": "CI=true npm test",
-		"precommit": "npm run test:ci",
-		"prepush": "npm run test:ci && npm run lint",
+		"precommit": "lint-staged",
+		"prepush": "lint-staged",
 		"lint": "eslint src",
 		"lint-fix": "eslint --fix src"
 	},
@@ -38,8 +38,13 @@
 		"eslint-plugin-import": "^2.13.0",
 		"eslint-plugin-node": "^6.0.1",
 		"eslint-plugin-promise": "^3.8.0",
+		"eslint-plugin-react": "^7.10.0",
 		"eslint-plugin-standard": "^3.1.0",
 		"husky": "^0.14.3",
+		"lint-staged": "^7.2.0",
 		"redux-devtools-extension": "^2.13.5"
+	},
+	"lint-staged": {
+		"*.js": ["eslint --fix", "git add"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
 		"start": "react-scripts start",
 		"build": "react-scripts build",
 		"test": "react-scripts test --env=jsdom",
-		"eject": "react-scripts eject"
+		"eject": "react-scripts eject",
+		"test:ci": "CI=true npm test",
+		"precommit": "npm run test:ci",
+		"prepush": "npm run test:ci"
 	},
 	"license": "MIT",
 	"repository": {
@@ -28,6 +31,7 @@
 		"url": "git://github.com/benjspriggs/iron.git"
 	},
 	"devDependencies": {
+		"husky": "^0.14.3",
 		"redux-devtools-extension": "^2.13.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"eject": "react-scripts eject",
 		"test:ci": "CI=true npm test",
 		"precommit": "npm run test:ci",
-		"prepush": "npm run test:ci"
+		"prepush": "npm run test:ci && npm run lint",
+		"lint": "eslint src",
+		"lint-fix": "eslint --fix src"
 	},
 	"license": "MIT",
 	"repository": {
@@ -31,6 +33,12 @@
 		"url": "git://github.com/benjspriggs/iron.git"
 	},
 	"devDependencies": {
+		"eslint": "^5.1.0",
+		"eslint-config-standard": "^11.0.0",
+		"eslint-plugin-import": "^2.13.0",
+		"eslint-plugin-node": "^6.0.1",
+		"eslint-plugin-promise": "^3.8.0",
+		"eslint-plugin-standard": "^3.1.0",
 		"husky": "^0.14.3",
 		"redux-devtools-extension": "^2.13.5"
 	}


### PR DESCRIPTION
## problem

There are no code quality precommit or pre-push hooks! Code can have mixed spaces, indent, etc.

## solution

This PR:
- adds husky for precommit and prepush hooks to git
- adds eslint as a js linter
- adds precommit and prepush hooks for standard react-app javascript styling
- updates existing code to use the new style

## discussion

Per #22.

Paging @benjspriggs!
