### PR TITLE
Improve performance for rendered posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "react-lazy-load": "^3.0.13",
     "react-redux": "^5.0.7",
     "react-render-html": "^0.6.0",
     "react-router-dom": "^4.3.1",

--- a/src/BlogPosts.js
+++ b/src/BlogPosts.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import { connect } from "react-redux"
 import { Link } from "react-router-dom"
 import { Button, Icon, List } from "semantic-ui-react"
+import LazyLoad from "react-lazy-load"
 
 import BlogPost from "./BlogPost"
 
@@ -17,9 +18,11 @@ const EnhancedBlogPost = (post, id) => (
 )
 
 const BlogPosts = ({ posts }) => (
-  <List relaxed divided>
-    {posts.map(EnhancedBlogPost)}
-  </List>
+  <LazyLoad>
+    <List relaxed divided>
+      {posts.map(EnhancedBlogPost)}
+    </List>
+  </LazyLoad>
 )
 
 BlogPosts.propTypes = {


### PR DESCRIPTION
## problem
Rendering a lot of posts (>50) is slow.

## solution

This adds [react-lazy-load](https://www.npmjs.com/package/react-lazy-load) to load elements dynamically as you scroll.

## discussion


Paging @benjspriggs!
